### PR TITLE
Adiciona instaladores para Windows e Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,26 @@ nerd_rats/
 └── install.sh         # Script de instalação para Linux
 ```
 
-## Requisitos
-
-- Python 3.7 ou superior
-- Bibliotecas Python (instaladas automaticamente):
-  - pynput>=1.7.6
-  - requests>=2.31.0
-  - python-dotenv>=1.0.0
-
 ## Instalação
 
 ### Windows
-
-1. Execute o script `install.bat` como administrador
-2. O programa será instalado e configurado para iniciar com o Windows
+1. Baixe o arquivo `NerdRats.exe` da última release
+2. Execute o programa
+3. Na primeira execução, configure seu email e usuário do GitHub
+4. O programa iniciará automaticamente com o Windows
 
 ### Linux
-
-1. Execute o script de instalação como root:
+1. Baixe o script `install_linux.sh`
+2. Dê permissão de execução:
    ```bash
-   sudo ./install.sh
+   chmod +x install_linux.sh
    ```
-2. O programa será instalado como serviço systemd e iniciará automaticamente
-
-## Configuração
-
-- Na primeira execução, o programa solicitará:
-  - Seu email
-  - Seu usuário do GitHub
-- As configurações são armazenadas em:
-  - Windows: `%APPDATA%\nerd_rats\config.conf`
-  - Linux: `/etc/nerd_rats.conf`
+3. Execute como root:
+   ```bash
+   sudo ./install_linux.sh
+   ```
+4. Na primeira execução, configure seu email e usuário do GitHub
+5. O programa será instalado como serviço e iniciará automaticamente
 
 ## Funcionalidades
 
@@ -69,8 +58,30 @@ O programa envia os seguintes dados para o backend:
 }
 ```
 
-## Variáveis de Ambiente
+## Configurações
 
+As configurações são armazenadas em:
+- Windows: `%APPDATA%\nerd_rats\config.conf`
+- Linux: `/etc/nerd_rats.conf`
+
+## Para Desenvolvedores
+
+### Requisitos
+- Python 3.7 ou superior
+- Bibliotecas Python:
+  - pynput>=1.7.6
+  - requests>=2.31.0
+  - python-dotenv>=1.0.0
+
+### Gerando Executável (Windows)
+1. Clone o repositório
+2. Execute:
+   ```bash
+   python build_exe.py
+   ```
+3. O executável será gerado na pasta `dist`
+
+### Variáveis de Ambiente
 - `TRACKING_POST_URL`: URL para envio dos dados (padrão: http://localhost:5000/track)
-- `TRACKING_INTERVAL`: Intervalo de envio em segundos (padrão: 15)
+- `TRACKING_INTERVAL`: Intervalo de envio em segundos (padrão: 20)
 - `CONFIG_PATH`: Caminho do arquivo de configuração

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,21 @@
+import PyInstaller.__main__
+import os
+import sys
+
+def build_windows_exe():
+    """Gera o executável para Windows"""
+    PyInstaller.__main__.run([
+        'src/presentation/cli/main.py',  # Script principal
+        '--name=NerdRats',               # Nome do executável
+        '--onefile',                     # Gerar um único arquivo
+        '--noconsole',                   # Sem console
+        '--hidden-import=pynput.keyboard._win32',  # Imports necessários
+        '--hidden-import=pynput.mouse._win32',
+    ])
+
+if __name__ == "__main__":
+    # Instala dependências necessárias
+    os.system('pip install -r requirements.txt')
+    
+    # Gera o executável
+    build_windows_exe() 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Verifica se está rodando como root
+if [ "$EUID" -ne 0 ]; then 
+    echo "Por favor, execute como root (sudo ./install_linux.sh)"
+    exit 1
+fi
+
+# Cria diretório de instalação
+INSTALL_DIR="/opt/nerd_rats"
+mkdir -p "$INSTALL_DIR"
+
+# Copia arquivos
+cp -r src/ requirements.txt "$INSTALL_DIR/"
+
+# Cria ambiente virtual e instala dependências
+python3 -m venv "$INSTALL_DIR/venv"
+source "$INSTALL_DIR/venv/bin/activate"
+pip install -r requirements.txt
+
+# Cria arquivo .env
+cat > "$INSTALL_DIR/.env" << EOL
+TRACKING_POST_URL=http://localhost:5000/track
+TRACKING_INTERVAL=20
+CONFIG_PATH=/etc/nerd_rats.conf
+EOL
+
+# Cria serviço systemd
+cat > /etc/systemd/system/nerd_rats.service << EOL
+[Unit]
+Description=NerdRats Event Tracker
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=$INSTALL_DIR/venv/bin/python $INSTALL_DIR/src/presentation/cli/main.py
+Restart=always
+User=$SUDO_USER
+Environment=PYTHONPATH=$INSTALL_DIR
+Environment=DISPLAY=:0
+
+[Install]
+WantedBy=multi-user.target
+EOL
+
+# Configura permissões
+chown -R $SUDO_USER:$SUDO_USER "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR/src/presentation/cli/main.py"
+
+# Inicia o serviço
+systemctl daemon-reload
+systemctl enable nerd_rats
+systemctl start nerd_rats
+
+echo "Instalação concluída! O serviço foi iniciado e será executado automaticamente na inicialização." 


### PR DESCRIPTION
## Descrição
Implementa métodos de instalação para Windows e Linux, permitindo uma distribuição mais fácil do NerdRats.

### Principais Alterações
- ✨ Adiciona executável único para Windows (NerdRats.exe)
- 🐧 Implementa script de instalação para Linux com serviço systemd
- 📝 Atualiza documentação com instruções de instalação
- 🧹 Remove arquivo de ícone não utilizado (assets/icon.ico)

### Detalhes Técnicos
#### Windows
- Implementa `build_exe.py` usando PyInstaller
- Gera executável único e sem console
- Inclui dependências necessárias do pynput

#### Linux
- Script `install_linux.sh` para instalação automatizada
- Configura serviço systemd para execução em segundo plano
- Cria ambiente virtual Python isolado
- Define permissões e variáveis de ambiente adequadas

### Instruções de Teste
#### Windows
1. Execute `python build_exe.py`
2. Verifique o executável gerado em `dist/NerdRats.exe`
3. Teste a execução do programa

#### Linux
1. Execute `sudo ./install_linux.sh`
2. Verifique o status do serviço: `systemctl status nerd_rats`
3. Confirme o rastreamento de eventos

### Notas Adicionais
- O executável Windows é gerado sem ícone personalizado para maior simplicidade
- O serviço Linux é configurado para iniciar automaticamente com o sistema
- Todas as dependências são gerenciadas via requirements.txt