### PR TITLE
fix: Corrige inicialização do StatsAggregator removendo parâmetro repository não utilizado

### DIFF
--- a/src/application/use_cases/track_events_use_case.py
+++ b/src/application/use_cases/track_events_use_case.py
@@ -70,7 +70,6 @@ class TrackEventsUseCase:
         self.aggregator = StatsAggregator(
             mouse_service=self.mouse_service,
             keyboard_service=self.keyboard_service,
-            repository=self.repository,
             user_github=self.github,
             email=self.email
         )


### PR DESCRIPTION
## Descrição
Este PR corrige um erro na inicialização da classe StatsAggregator onde um parâmetro 'repository' estava sendo passado incorretamente, causando o erro:
`TypeError: StatsAggregator.__init__() got an unexpected keyword argument 'repository'`

## Mudanças
- Removido o parâmetro `repository` da inicialização do StatsAggregator em `track_events_use_case.py`
- O construtor do StatsAggregator espera apenas: mouse_service, keyboard_service, user_github e email

## Testes
- [ ] Executar o programa e verificar se o erro de inicialização foi resolvido
- [ ] Confirmar que o rastreamento de eventos está funcionando corretamente

## Impacto
- Corrige o erro que impedia a inicialização do programa
- Não há alterações na lógica de negócios ou no comportamento esperado do sistema