### PR TITLE
fix: Remove URLs do localhost e padroniza para URL de produção

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ As configurações são armazenadas em:
 3. O executável será gerado na pasta `dist`
 
 ### Variáveis de Ambiente
-- `TRACKING_POST_URL`: URL para envio dos dados (padrão: http://localhost:5000/track)
+- `TRACKING_POST_URL`: URL para envio dos dados (padrão: https://nerds-rats-hackathon.onrender.com/metrics)
 - `TRACKING_INTERVAL`: Intervalo de envio em segundos (padrão: 20)
 - `CONFIG_PATH`: Caminho do arquivo de configuração

--- a/install.bat
+++ b/install.bat
@@ -35,7 +35,7 @@ if errorlevel 1 (
 if not exist "%APPDATA%\nerd_rats" mkdir "%APPDATA%\nerd_rats"
 
 :: Cria arquivo .env com configurações
-echo TRACKING_POST_URL=http://localhost:5000/track> .env
+echo TRACKING_POST_URL=https://nerds-rats-hackathon.onrender.com/metrics> .env
 echo TRACKING_INTERVAL=15>> .env
 echo CONFIG_PATH=%APPDATA%\nerd_rats\config.conf>> .env
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ cp -r src/ requirements.txt "$INSTALL_DIR/"
 
 # Cria arquivo .env com configurações
 cat > "$INSTALL_DIR/.env" << EOL
-TRACKING_POST_URL=http://localhost:5000/track
+TRACKING_POST_URL=https://nerds-rats-hackathon.onrender.com/metrics
 TRACKING_INTERVAL=15
 CONFIG_PATH=/etc/nerd_rats.conf
 EOL

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -20,7 +20,7 @@ pip install -r requirements.txt
 
 # Cria arquivo .env
 cat > "$INSTALL_DIR/.env" << EOL
-TRACKING_POST_URL=http://localhost:5000/track
+TRACKING_POST_URL=https://nerds-rats-hackathon.onrender.com/metrics
 TRACKING_INTERVAL=20
 CONFIG_PATH=/etc/nerd_rats.conf
 EOL


### PR DESCRIPTION
## Descrição
Este PR remove todas as referências à URL do localhost (http://localhost:5000/track) e padroniza para usar a URL de produção (https://nerds-rats-hackathon.onrender.com/metrics) em todos os arquivos de instalação e documentação.

## Mudanças
- Atualizado `install.bat` para usar a URL de produção
- Atualizado `install.sh` para usar a URL de produção
- Atualizado `install_linux.sh` para usar a URL de produção
- Atualizado `README.md` para refletir a URL de produção como padrão

## Impacto
- Evita confusão com URLs diferentes em diferentes arquivos
- Garante que todas as instalações apontem para o servidor de produção por padrão
- Mantém consistência na documentação

## Testes
- [ ] Verificar se a instalação em Windows está funcionando corretamente
- [ ] Verificar se a instalação em Linux está funcionando corretamente
- [ ] Confirmar que as métricas estão sendo enviadas para o servidor de produção