### PR TITLE
fix: Adiciona carregamento do arquivo .env no início do programa

### DIFF
--- a/src/presentation/cli/main.py
+++ b/src/presentation/cli/main.py
@@ -2,6 +2,10 @@ import signal
 import sys
 import os
 import sys
+from dotenv import load_dotenv
+
+# Carrega variáveis de ambiente do arquivo .env
+load_dotenv()
 
 # Adiciona o diretório raiz ao PYTHONPATH
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))


### PR DESCRIPTION
## Descrição
Este PR corrige um problema onde as variáveis de ambiente do arquivo `.env` não estavam sendo carregadas corretamente, fazendo com que o programa ignorasse a URL configurada e tentasse usar o localhost.

## Mudanças
- Adicionado o carregamento do arquivo `.env` usando `python-dotenv` no início do programa (`main.py`)
- Garante que as configurações do arquivo `.env` sejam carregadas antes de qualquer outra operação

## Impacto
- Corrige o erro onde o programa tentava enviar dados para `http://localhost:5000/track` mesmo quando configurado para usar a URL de produção
- Garante que todas as variáveis de ambiente do arquivo `.env` sejam carregadas corretamente

## Testes
- [ ] Verificar se o programa está lendo corretamente a URL do arquivo `.env`
- [ ] Confirmar que as métricas estão sendo enviadas para a URL correta
- [ ] Testar com diferentes configurações no arquivo `.env`